### PR TITLE
Use the login from oauth instead of the (optional) name

### DIFF
--- a/src/main/java/com/jcertif/pic/sonar/oauth/OAuthAuthenticator.java
+++ b/src/main/java/com/jcertif/pic/sonar/oauth/OAuthAuthenticator.java
@@ -22,7 +22,6 @@ package com.jcertif.pic.sonar.oauth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.security.Authenticator;
-import org.sonar.api.security.UserDetails;
 
 /**
  *
@@ -35,8 +34,8 @@ public class OAuthAuthenticator extends Authenticator {
 
     @Override
     public boolean doAuthenticate(Context context) {
-        UserDetails user = (UserDetails) context.getRequest().getAttribute(OAuthUsersProvider.OAUTH_USER_KEY);
-        LOGGER.info("User : {}", user);
+        OAuthUserDetails user = (OAuthUserDetails) context.getRequest().getAttribute(OAuthUsersProvider.OAUTH_USER_KEY);
+        LOGGER.info("User : {} - Username : {}", user, context.getUsername());
         return user != null;
     }
 

--- a/src/main/java/com/jcertif/pic/sonar/oauth/OAuthUserDetails.java
+++ b/src/main/java/com/jcertif/pic/sonar/oauth/OAuthUserDetails.java
@@ -1,0 +1,80 @@
+/*
+ * Sonar OAuth Plugin
+ * Copyright (C) 2014 JCertif
+ * lab@jcertif.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package com.jcertif.pic.sonar.oauth;
+
+import com.google.common.base.Objects;
+import org.sonar.api.security.UserDetails;
+
+/**
+ * Created by Jean Blanchard on 15/10/14.
+ */
+public class OAuthUserDetails {
+  private UserDetails details;
+  private String login;
+
+  public UserDetails getDetails() {
+    return details;
+  }
+
+  public String getLogin() {
+    return login;
+  }
+
+  @Override
+  public String toString() {
+      return Objects.toStringHelper(this)
+              .add("login", login)
+              .add("name", details.getName())
+              .add("email", details.getEmail())
+              .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private OAuthUserDetails instance;
+
+    private Builder() {
+      instance = new OAuthUserDetails();
+      instance.details = new UserDetails();
+    }
+
+    public Builder login(String login) {
+      instance.login = login;
+      return this;
+    }
+
+    public Builder name(String name) {
+      instance.details.setName(name);
+      return this;
+    }
+
+    public Builder email(String email) {
+      instance.details.setEmail(email);
+      return this;
+    }
+
+    public OAuthUserDetails build() {
+      return instance;
+    }
+  }
+}

--- a/src/main/java/com/jcertif/pic/sonar/oauth/OAuthUsersProvider.java
+++ b/src/main/java/com/jcertif/pic/sonar/oauth/OAuthUsersProvider.java
@@ -36,9 +36,9 @@ public class OAuthUsersProvider extends ExternalUsersProvider {
 
     @Override
     public UserDetails doGetUserDetails(Context context) {
-        UserDetails user = (UserDetails) context.getRequest().getAttribute(OAUTH_USER_KEY);
+        OAuthUserDetails user = (OAuthUserDetails) context.getRequest().getAttribute(OAUTH_USER_KEY);
         LOGGER.info("Stored user : {}", user);
-        return user;
+        return user.getDetails();
     }
 
 }

--- a/src/main/java/com/jcertif/pic/sonar/oauth/OAuthValidationFilter.java
+++ b/src/main/java/com/jcertif/pic/sonar/oauth/OAuthValidationFilter.java
@@ -54,7 +54,7 @@ public class OAuthValidationFilter extends ServletFilter {
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        UserDetails user = oauthClient.validate(servletRequest.getParameterMap());
+        OAuthUserDetails user = oauthClient.validate(servletRequest.getParameterMap());
         HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
         if (user == null) {

--- a/src/main/java/org/sonar/plugins/oauth/providers/GithubClient.java
+++ b/src/main/java/org/sonar/plugins/oauth/providers/GithubClient.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.oauth.providers;
 
 import com.google.common.base.Preconditions;
 import com.jcertif.pic.sonar.oauth.OAuthQueryParams;
+import com.jcertif.pic.sonar.oauth.OAuthUserDetails;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.sonar.api.Properties;
@@ -100,9 +101,17 @@ public class GithubClient extends OAuthClient {
     }
 
     @Override
-    public void fillUser(JSONObject jsonObject, UserDetails user) {
-        user.setEmail(jsonObject.getString("email"));
-        user.setName(jsonObject.getString("name"));
+    public OAuthUserDetails buildUser(JSONObject jsonObject) {
+        String login = jsonObject.getString("login");
+        String name = jsonObject.getString("name");
+        if (StringUtils.isBlank(name)) {
+            name = login;
+        }
+        return OAuthUserDetails.builder()
+                .login(login)
+                .name(name)
+                .email(jsonObject.getString("email"))
+                .build();
     }
 
     public static final class Settings {

--- a/src/main/java/org/sonar/plugins/oauth/providers/GoogleClient.java
+++ b/src/main/java/org/sonar/plugins/oauth/providers/GoogleClient.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.oauth.providers;
 
 import com.google.common.base.Preconditions;
 import com.jcertif.pic.sonar.oauth.OAuthQueryParams;
+import com.jcertif.pic.sonar.oauth.OAuthUserDetails;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.sonar.api.Properties;
@@ -86,9 +87,12 @@ public class GoogleClient extends OAuthClient {
     }
 
     @Override
-    public void fillUser(JSONObject jsonObject, UserDetails user) {
-        user.setEmail(jsonObject.getJSONArray("emails").getJSONObject(0).getString("value"));
-        user.setName(jsonObject.getString("displayName"));
+    public OAuthUserDetails buildUser(JSONObject jsonObject) {
+        return OAuthUserDetails.builder()
+                .login(jsonObject.getString("id"))
+                .name(jsonObject.getString("displayName"))
+                .email(jsonObject.getJSONArray("emails").getJSONObject(0).getString("value"))
+                .build();
     }
 
     @Override

--- a/src/main/resources/org/sonar/ror/oauth/app/controllers/oauth_controller.rb
+++ b/src/main/resources/org/sonar/ror/oauth/app/controllers/oauth_controller.rb
@@ -4,7 +4,7 @@ class OauthController < ApplicationController
 
   def validate
     begin
-      self.current_user = User.authenticate(nil, nil, servlet_request)
+      self.current_user = User.authenticate(servlet_request['oauth_user'].login, nil, servlet_request)
 
     rescue Exception => e
       self.current_user = nil


### PR DESCRIPTION
When a user is created, the login is currently positioned by default to the name. This is bad because the name field is optional (especially in GitHub), resulting in an incorrect user being created.

This PR fetches the login from oauth, and uses it as the username (=login) in SonarQube. Also, if the name is not set, it is positioned to the login.

Note : not tested with Google, as it requires a public-facing website.
